### PR TITLE
Fix #37: Can we identify merge commits to link commits to PRs?

### DIFF
--- a/lib/ruby_maat.rb
+++ b/lib/ruby_maat.rb
@@ -17,6 +17,7 @@ require_relative "ruby_maat/parsers/tfs_parser"
 require_relative "ruby_maat/groupers/layer_grouper"
 require_relative "ruby_maat/groupers/time_grouper"
 require_relative "ruby_maat/groupers/team_mapper"
+require_relative "ruby_maat/groupers/merge_commit_grouper"
 
 # Analysis modules (load before app.rb since app references them)
 require_relative "ruby_maat/analysis/base_analysis"

--- a/lib/ruby_maat/app.rb
+++ b/lib/ruby_maat/app.rb
@@ -97,10 +97,11 @@ module RubyMaat
 
     def apply_merge_grouping(change_records)
       return change_records unless @options[:group_by_merge]
+      return change_records if change_records.nil? || change_records.empty?
 
       # Check for non-nil parent_revisions (not non-empty) because root commits
       # legitimately have parent_revisions == [] when parsed with the parents format.
-      has_parent_metadata = change_records&.any? { |record| !record.parent_revisions.nil? }
+      has_parent_metadata = change_records.any? { |record| !record.parent_revisions.nil? }
 
       unless has_parent_metadata
         raise ArgumentError,

--- a/lib/ruby_maat/app.rb
+++ b/lib/ruby_maat/app.rb
@@ -101,11 +101,17 @@ module RubyMaat
 
       # Check for non-nil parent_revisions (not non-empty) because root commits
       # legitimately have parent_revisions == [] when parsed with the parents format.
-      has_parent_metadata = change_records.any? { |record| !record.parent_revisions.nil? }
+      records_with_parents = change_records.count { |record| !record.parent_revisions.nil? }
+      records_without_parents = change_records.count { |record| record.parent_revisions.nil? }
 
-      unless has_parent_metadata
+      if records_with_parents.zero?
         raise ArgumentError,
           "--group-by-merge requires parent revision metadata in the log. " \
+          "Please regenerate the log using the 'pr-coupling' preset or another format that includes parent hashes."
+      elsif records_without_parents.positive?
+        raise ArgumentError,
+          "--group-by-merge requires parent revision metadata for all commits, " \
+          "but the provided log mixes records with and without parent hashes. " \
           "Please regenerate the log using the 'pr-coupling' preset or another format that includes parent hashes."
       end
 

--- a/lib/ruby_maat/app.rb
+++ b/lib/ruby_maat/app.rb
@@ -44,6 +44,7 @@ module RubyMaat
       change_records = parser.parse
 
       # Apply data transformations
+      change_records = apply_merge_grouping(change_records)
       change_records = apply_grouping(change_records)
       change_records = apply_temporal_grouping(change_records)
       change_records = apply_team_mapping(change_records)
@@ -92,6 +93,13 @@ module RubyMaat
       when "tfs"
         RubyMaat::Parsers::TfsParser.new(@options[:log], @options)
       end
+    end
+
+    def apply_merge_grouping(change_records)
+      return change_records unless @options[:group_by_merge]
+
+      grouper = RubyMaat::Groupers::MergeCommitGrouper.new
+      grouper.group(change_records)
     end
 
     def apply_grouping(change_records)

--- a/lib/ruby_maat/app.rb
+++ b/lib/ruby_maat/app.rb
@@ -98,6 +98,14 @@ module RubyMaat
     def apply_merge_grouping(change_records)
       return change_records unless @options[:group_by_merge]
 
+      has_parent_metadata = change_records&.any? { |record| record.parent_revisions && !record.parent_revisions.empty? }
+
+      unless has_parent_metadata
+        raise ArgumentError,
+          "--group-by-merge requires parent revision metadata in the log. " \
+          "Please regenerate the log using the 'pr-coupling' preset or another format that includes parent hashes."
+      end
+
       grouper = RubyMaat::Groupers::MergeCommitGrouper.new
       grouper.group(change_records)
     end

--- a/lib/ruby_maat/app.rb
+++ b/lib/ruby_maat/app.rb
@@ -98,7 +98,9 @@ module RubyMaat
     def apply_merge_grouping(change_records)
       return change_records unless @options[:group_by_merge]
 
-      has_parent_metadata = change_records&.any? { |record| record.parent_revisions && !record.parent_revisions.empty? }
+      # Check for non-nil parent_revisions (not non-empty) because root commits
+      # legitimately have parent_revisions == [] when parsed with the parents format.
+      has_parent_metadata = change_records&.any? { |record| !record.parent_revisions.nil? }
 
       unless has_parent_metadata
         raise ArgumentError,

--- a/lib/ruby_maat/change_record.rb
+++ b/lib/ruby_maat/change_record.rb
@@ -4,9 +4,10 @@ module RubyMaat
   # Represents a single change/modification record from VCS
   # This is the fundamental data structure that flows through the entire pipeline
   class ChangeRecord
-    attr_reader :entity, :author, :date, :revision, :message, :loc_added, :loc_deleted
+    attr_reader :entity, :author, :date, :revision, :message, :loc_added, :loc_deleted, :parent_revisions
 
-    def initialize(entity:, author:, date:, revision:, message: nil, loc_added: nil, loc_deleted: nil)
+    def initialize(entity:, author:, date:, revision:, message: nil, loc_added: nil, loc_deleted: nil,
+      parent_revisions: nil)
       @entity = entity
       @author = author
       @date = date.is_a?(Date) ? date : Date.parse(date)
@@ -14,6 +15,11 @@ module RubyMaat
       @message = message
       @loc_added = loc_added.to_i if loc_added && (!loc_added.is_a?(Float) || !loc_added.nan?)
       @loc_deleted = loc_deleted.to_i if loc_deleted && (!loc_deleted.is_a?(Float) || !loc_deleted.nan?)
+      @parent_revisions = parent_revisions
+    end
+
+    def merge_commit?
+      parent_revisions.is_a?(Array) && parent_revisions.size >= 2
     end
 
     def to_h

--- a/lib/ruby_maat/change_record.rb
+++ b/lib/ruby_maat/change_record.rb
@@ -30,7 +30,8 @@ module RubyMaat
         revision: revision,
         message: message,
         loc_added: loc_added,
-        loc_deleted: loc_deleted
+        loc_deleted: loc_deleted,
+        parent_revisions: parent_revisions
       }
     end
 

--- a/lib/ruby_maat/cli.rb
+++ b/lib/ruby_maat/cli.rb
@@ -362,6 +362,12 @@ module RubyMaat
           raise ArgumentError, "Invalid date format for --age-time-now: #{date_str}. Use YYYY-MM-dd format."
         end
 
+        opts.on("--group-by-merge",
+          "Group commits by merge commit for PR-level coupling analysis. " \
+          "Requires log generated with parent hashes (use --preset pr-coupling).") do
+          @options[:group_by_merge] = true
+        end
+
         opts.on("--verbose-results",
           "Includes additional analysis details together with the results. Only implemented for change coupling.") do
           @options[:verbose_results] = true

--- a/lib/ruby_maat/generators/git_generator.rb
+++ b/lib/ruby_maat/generators/git_generator.rb
@@ -97,10 +97,12 @@ module RubyMaat
         # Format selection
         puts "Output formats:"
         puts "  1. git2 (recommended, faster parsing)"
-        puts "  2. legacy (backward compatibility)"
+        puts "  2. git2-parents (git2 with parent hashes, for --group-by-merge)"
+        puts "  3. legacy (backward compatibility)"
 
-        format_choice = ask_integer("Choose format", 1, 2)
-        options[:format] = (format_choice == 1) ? "git2" : "legacy"
+        format_choice = ask_integer("Choose format", 1, 3)
+        formats = {1 => "git2", 2 => "git2-parents", 3 => "legacy"}
+        options[:format] = formats[format_choice]
 
         # Branch selection
         options[:all_branches] = ask_yes_no("Include all branches?", options[:all_branches])

--- a/lib/ruby_maat/generators/git_generator.rb
+++ b/lib/ruby_maat/generators/git_generator.rb
@@ -48,6 +48,14 @@ module RubyMaat
             no_renames: true,
             all_branches: true
           }
+        },
+        "pr-coupling" => {
+          description: "Format with parent hashes for PR-level coupling analysis (use with --group-by-merge)",
+          options: {
+            format: "git2-parents",
+            no_renames: true,
+            all_branches: true
+          }
         }
       }.freeze
 
@@ -72,6 +80,8 @@ module RubyMaat
         case format
         when "git2"
           build_git2_command(options)
+        when "git2-parents"
+          build_git2_parents_command(options)
         when "legacy"
           build_legacy_command(options)
         else
@@ -130,6 +140,25 @@ module RubyMaat
         parts << "--author=#{shell_escape(options[:author])}" if options[:author]
 
         # Add path at the end if specified (with shell escaping)
+        parts << "--" << shell_escape(options[:path]) if options[:path]
+
+        parts.join(" ")
+      end
+
+      def build_git2_parents_command(options)
+        parts = ["git", "log"]
+
+        parts << "--all" if options[:all_branches]
+        parts << "--numstat"
+        parts << "--date=short"
+        parts << "--pretty=format:'--%h--%p--%ad--%aN--%s'"
+        parts << "--no-renames" if options[:no_renames]
+
+        parts << "--after=#{shell_escape(validate_date(options[:since]))}" if options[:since]
+        parts << "--before=#{shell_escape(validate_date(options[:until]))}" if options[:until]
+
+        parts << "--author=#{shell_escape(options[:author])}" if options[:author]
+
         parts << "--" << shell_escape(options[:path]) if options[:path]
 
         parts.join(" ")

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Set is a built-in class since Ruby 3.2 (the project's minimum version),
-# so an explicit require is not needed and would trigger Lint/RedundantRequireStatement.
+# NOTE: Set has been a built-in class since Ruby 3.2, which is this project's
+# minimum version (required_ruby_version >= 3.2.0).  Adding `require "set"`
+# here is unnecessary and triggers RuboCop's Lint/RedundantRequireStatement.
 
 module RubyMaat
   module Groupers

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Set is a built-in class since Ruby 3.2 (the project's minimum version),
+# so an explicit require is not needed and would trigger Lint/RedundantRequireStatement.
+
 module RubyMaat
   module Groupers
     # Groups commits by their merge commit to enable PR-level coupling analysis.
@@ -41,12 +44,16 @@ module RubyMaat
         merges = commits.select { |_, info| info[:merge] }
 
         merges.each do |merge_rev, info|
-          feature_parent = info[:parents][1]
-          mainline_parent = info[:parents][0]
-          next unless feature_parent && mainline_parent
+          parents = info[:parents] || []
+          mainline_parent = parents[0]
+          next unless mainline_parent && parents.length > 1
 
-          feature_commits = find_feature_commits(feature_parent, mainline_parent, commits)
-          feature_commits.each { |rev| merge_map[rev] = merge_rev }
+          # Handle octopus merges (3+ parents) by iterating all feature parents
+          feature_parents = parents[1..].compact
+          feature_parents.each do |feature_parent|
+            feature_commits = find_feature_commits(feature_parent, mainline_parent, commits)
+            feature_commits.each { |rev| merge_map[rev] = merge_rev }
+          end
         end
 
         merge_map
@@ -107,7 +114,8 @@ module RubyMaat
               revision: merge_rev,
               message: record.message,
               loc_added: record.loc_added,
-              loc_deleted: record.loc_deleted
+              loc_deleted: record.loc_deleted,
+              parent_revisions: record.parent_revisions
             )
           else
             record

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -53,15 +53,19 @@ module RubyMaat
       end
 
       # Walk backward from the feature branch tip, collecting commits that belong
-      # to this merge. Stop when we reach the mainline parent or a commit not in
-      # our log.
+      # to this merge. Excludes any commits reachable from the mainline parent so
+      # that intermediate merges from main into the feature branch don't pull in
+      # unrelated mainline history.
       def find_feature_commits(start, stop, commits)
+        mainline_ancestors = collect_ancestors(stop, commits)
         visited = Set.new
         queue = [start]
+        head = 0
 
-        while queue.any?
-          current = queue.shift
-          next if current == stop || visited.include?(current) || !commits.key?(current)
+        while head < queue.length
+          current = queue[head]
+          head += 1
+          next if mainline_ancestors.include?(current) || visited.include?(current) || !commits.key?(current)
 
           visited << current
 
@@ -70,6 +74,26 @@ module RubyMaat
         end
 
         visited
+      end
+
+      # Collect all ancestors reachable from a given commit (inclusive).
+      def collect_ancestors(start, commits)
+        ancestors = Set.new
+        queue = [start]
+        head = 0
+
+        while head < queue.length
+          current = queue[head]
+          head += 1
+          next if ancestors.include?(current) || !commits.key?(current)
+
+          ancestors << current
+
+          parents = commits[current][:parents]
+          parents&.each { |p| queue << p }
+        end
+
+        ancestors
       end
 
       def rewrite_records(records, merge_map)

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# NOTE: Set has been a built-in class since Ruby 3.2, which is this project's
-# minimum version (required_ruby_version >= 3.2.0).  Adding `require "set"`
-# here is unnecessary and triggers RuboCop's Lint/RedundantRequireStatement.
+# NOTE: Set has been a built-in class (autoloaded without require) since
+# Ruby 3.2, which is this project's minimum version (see gemspec:
+# required_ruby_version >= "3.2.0").  An explicit `require "set"` is
+# unnecessary and triggers RuboCop's Lint/RedundantRequireStatement cop.
 
 module RubyMaat
   module Groupers
@@ -25,7 +26,8 @@ module RubyMaat
 
         return change_records if merge_map.empty?
 
-        rewrite_records(change_records, merge_map)
+        merge_dates = build_merge_dates(commit_info)
+        rewrite_records(change_records, merge_map, merge_dates)
       end
 
       private
@@ -34,7 +36,7 @@ module RubyMaat
         commits = {}
         records.each do |record|
           rev = record.revision
-          commits[rev] ||= {parents: record.parent_revisions || [], merge: false}
+          commits[rev] ||= {parents: record.parent_revisions || [], merge: false, date: record.date}
           commits[rev][:merge] = true if record.merge_commit?
         end
         commits
@@ -104,14 +106,24 @@ module RubyMaat
         ancestors
       end
 
-      def rewrite_records(records, merge_map)
+      # Build a lookup from merge revision to its date, used to align
+      # rewritten feature-branch records with the merge commit's date.
+      def build_merge_dates(commits)
+        dates = {}
+        commits.each do |rev, info|
+          dates[rev] = info[:date] if info[:merge]
+        end
+        dates
+      end
+
+      def rewrite_records(records, merge_map, merge_dates)
         records.map do |record|
           merge_rev = merge_map[record.revision]
           if merge_rev
             ChangeRecord.new(
               entity: record.entity,
               author: record.author,
-              date: record.date,
+              date: merge_dates[merge_rev] || record.date,
               revision: merge_rev,
               message: record.message,
               loc_added: record.loc_added,

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -51,10 +51,13 @@ module RubyMaat
           mainline_parent = parents[0]
           next unless mainline_parent && parents.length > 1
 
-          # Handle octopus merges (3+ parents) by iterating all feature parents
+          # Compute mainline ancestors once per merge commit and reuse across
+          # all feature parents, avoiding repeated graph walks for octopus merges.
+          mainline_ancestors = collect_ancestors(mainline_parent, commits)
+
           feature_parents = parents[1..].compact
           feature_parents.each do |feature_parent|
-            feature_commits = find_feature_commits(feature_parent, mainline_parent, commits)
+            feature_commits = find_feature_commits(feature_parent, mainline_ancestors, commits)
             feature_commits.each { |rev| merge_map[rev] = merge_rev }
           end
         end
@@ -66,8 +69,11 @@ module RubyMaat
       # to this merge. Excludes any commits reachable from the mainline parent so
       # that intermediate merges from main into the feature branch don't pull in
       # unrelated mainline history.
-      def find_feature_commits(start, stop, commits)
-        mainline_ancestors = collect_ancestors(stop, commits)
+      #
+      # +mainline_ancestors+ is a pre-computed Set of commits reachable from the
+      # mainline parent, passed in to avoid redundant graph walks when a merge
+      # has multiple feature parents (octopus merges).
+      def find_feature_commits(start, mainline_ancestors, commits)
         visited = Set.new
         queue = [start]
         head = 0

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -49,11 +49,17 @@ module RubyMaat
         merges.each do |merge_rev, info|
           parents = info[:parents] || []
           mainline_parent = parents[0]
-          next unless mainline_parent && parents.length > 1
+          # Skip this merge if it does not have a valid mainline parent present
+          # in the commit set, or if it is not a true merge (single parent).
+          next unless mainline_parent && parents.length > 1 && commits.key?(mainline_parent)
 
           # Compute mainline ancestors once per merge commit and reuse across
           # all feature parents, avoiding repeated graph walks for octopus merges.
           mainline_ancestors = collect_ancestors(mainline_parent, commits)
+          # If we cannot determine any ancestors for the mainline parent (for
+          # example due to a filtered log), skip grouping for this merge to
+          # avoid incorrect rewrites with an incomplete graph.
+          next if mainline_ancestors.empty?
 
           feature_parents = parents[1..].compact
           feature_parents.each do |feature_parent|

--- a/lib/ruby_maat/groupers/merge_commit_grouper.rb
+++ b/lib/ruby_maat/groupers/merge_commit_grouper.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module RubyMaat
+  module Groupers
+    # Groups commits by their merge commit to enable PR-level coupling analysis.
+    #
+    # When Git uses a merge-based workflow (e.g., GitHub PRs), individual commits
+    # on feature branches are combined into merge commits on the main branch.
+    # This grouper identifies merge commits and rewrites the revision of child
+    # commits so that all commits belonging to a merge share the same revision.
+    #
+    # This allows the coupling analysis to treat all files changed in a PR as
+    # co-changing, giving more meaningful coupling results.
+    #
+    # Requires log data generated with parent hashes:
+    #   git log --all --numstat --date=short --pretty=format:'--%h--%p--%ad--%aN--%s' --no-renames
+    class MergeCommitGrouper
+      def group(change_records)
+        commit_info = build_commit_info(change_records)
+        merge_map = build_merge_map(commit_info)
+
+        return change_records if merge_map.empty?
+
+        rewrite_records(change_records, merge_map)
+      end
+
+      private
+
+      def build_commit_info(records)
+        commits = {}
+        records.each do |record|
+          rev = record.revision
+          commits[rev] ||= {parents: record.parent_revisions || [], merge: false}
+          commits[rev][:merge] = true if record.merge_commit?
+        end
+        commits
+      end
+
+      def build_merge_map(commits)
+        merge_map = {}
+        merges = commits.select { |_, info| info[:merge] }
+
+        merges.each do |merge_rev, info|
+          feature_parent = info[:parents][1]
+          mainline_parent = info[:parents][0]
+          next unless feature_parent && mainline_parent
+
+          feature_commits = find_feature_commits(feature_parent, mainline_parent, commits)
+          feature_commits.each { |rev| merge_map[rev] = merge_rev }
+        end
+
+        merge_map
+      end
+
+      # Walk backward from the feature branch tip, collecting commits that belong
+      # to this merge. Stop when we reach the mainline parent or a commit not in
+      # our log.
+      def find_feature_commits(start, stop, commits)
+        visited = Set.new
+        queue = [start]
+
+        while queue.any?
+          current = queue.shift
+          next if current == stop || visited.include?(current) || !commits.key?(current)
+
+          visited << current
+
+          parents = commits[current][:parents]
+          parents&.each { |p| queue << p }
+        end
+
+        visited
+      end
+
+      def rewrite_records(records, merge_map)
+        records.map do |record|
+          merge_rev = merge_map[record.revision]
+          if merge_rev
+            ChangeRecord.new(
+              entity: record.entity,
+              author: record.author,
+              date: record.date,
+              revision: merge_rev,
+              message: record.message,
+              loc_added: record.loc_added,
+              loc_deleted: record.loc_deleted
+            )
+          else
+            record
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_maat/parsers/git2_parser.rb
+++ b/lib/ruby_maat/parsers/git2_parser.rb
@@ -15,6 +15,9 @@ module RubyMaat
     # --abc123--2015-06-16--Jane Doe--Fix bug in parser
     # 10      5       lib/example.rb
     class Git2Parser < BaseParser
+      # Format with parent hashes: --hash--parent1 parent2--date--author--message
+      COMMIT_WITH_PARENTS = /^--([a-z0-9]+)--([a-z0-9 ]*)--(\d{4}-\d{2}-\d{2})--([^-\r\n]+?)--([^\r\n]*)$/
+      # Standard format: --hash--date--author--message
       COMMIT_SEPARATOR = /^--([a-z0-9]+)--(\d{4}-\d{2}-\d{2})--([^-\r\n]+?)--([^\r\n]*)$/
       CHANGE_PATTERN = /^(-|\d+)[\t ]{1,10}(-|\d+)[\t ]{1,10}([^\r\n]*)$/
 
@@ -28,9 +31,19 @@ module RubyMaat
           line.strip!
           next if line.empty?
 
-          if (commit_match = line.match(COMMIT_SEPARATOR))
+          if (commit_match = line.match(COMMIT_WITH_PARENTS))
+            parents_str = commit_match[2].strip
             current_commit = {
               revision: commit_match[1],
+              parent_revisions: parents_str.empty? ? [] : parents_str.split,
+              date: parse_date(commit_match[3]),
+              author: commit_match[4].strip,
+              message: commit_match[5].strip
+            }
+          elsif (commit_match = line.match(COMMIT_SEPARATOR))
+            current_commit = {
+              revision: commit_match[1],
+              parent_revisions: nil,
               date: parse_date(commit_match[2]),
               author: commit_match[3].strip,
               message: commit_match[4].strip
@@ -50,7 +63,8 @@ module RubyMaat
               revision: current_commit[:revision],
               message: current_commit[:message],
               loc_added: added,
-              loc_deleted: deleted
+              loc_deleted: deleted,
+              parent_revisions: current_commit[:parent_revisions]
             )
           end
         end

--- a/lib/ruby_maat/parsers/git2_parser.rb
+++ b/lib/ruby_maat/parsers/git2_parser.rb
@@ -16,9 +16,9 @@ module RubyMaat
     # 10      5       lib/example.rb
     class Git2Parser < BaseParser
       # Format with parent hashes: --hash--parent1 parent2--date--author--message
-      COMMIT_WITH_PARENTS = /^--([a-z0-9]+)--([a-z0-9 ]*)--(\d{4}-\d{2}-\d{2})--([^-\r\n]+?)--([^\r\n]*)$/
+      COMMIT_WITH_PARENTS = /^--([a-z0-9]+)--([a-z0-9 ]*)--(\d{4}-\d{2}-\d{2})--([^\r\n]+?)--([^\r\n]*)$/
       # Standard format: --hash--date--author--message
-      COMMIT_SEPARATOR = /^--([a-z0-9]+)--(\d{4}-\d{2}-\d{2})--([^-\r\n]+?)--([^\r\n]*)$/
+      COMMIT_SEPARATOR = /^--([a-z0-9]+)--(\d{4}-\d{2}-\d{2})--([^\r\n]+?)--([^\r\n]*)$/
       CHANGE_PATTERN = /^(-|\d+)[\t ]{1,10}(-|\d+)[\t ]{1,10}([^\r\n]*)$/
 
       protected

--- a/spec/ruby_maat/app_spec.rb
+++ b/spec/ruby_maat/app_spec.rb
@@ -32,6 +32,30 @@ RSpec.describe RubyMaat::App do
       expect { app.run }.not_to raise_error
     end
 
+    it "raises an error when log has mixed records with and without parent metadata" do
+      allow(RubyMaat::Parsers::Git2Parser).to receive(:new).and_return(
+        instance_double(RubyMaat::Parsers::Git2Parser, parse: [
+          RubyMaat::ChangeRecord.new(
+            entity: "file1.rb", author: "dev", date: "2024-01-01",
+            revision: "abc123", parent_revisions: ["def456"]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file2.rb", author: "dev", date: "2024-01-01",
+            revision: "ghi789", parent_revisions: nil
+          )
+        ])
+      )
+
+      app = described_class.new(
+        log: log_file,
+        version_control: "git2",
+        analysis: "coupling",
+        group_by_merge: true
+      )
+
+      expect { app.run }.to raise_error(SystemExit).and output(/mixes records with and without parent hashes/).to_stderr
+    end
+
     it "does not raise when log has parent metadata but only root commits (empty parent lists)" do
       # Root commits legitimately have parent_revisions == [] when parsed with the parents format.
       # The validation should detect that parent metadata is present (non-nil) and not error.

--- a/spec/ruby_maat/app_spec.rb
+++ b/spec/ruby_maat/app_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe RubyMaat::App do
       expect { app.run }.to raise_error(SystemExit).and output(/group-by-merge requires parent revision metadata/).to_stderr
     end
 
+    it "does not raise when log yields empty change records" do
+      allow(RubyMaat::Parsers::Git2Parser).to receive(:new).and_return(
+        instance_double(RubyMaat::Parsers::Git2Parser, parse: [])
+      )
+
+      app = described_class.new(
+        log: log_file,
+        version_control: "git2",
+        analysis: "revisions",
+        group_by_merge: true
+      )
+
+      expect { app.run }.not_to raise_error
+    end
+
     it "does not raise when log has parent metadata but only root commits (empty parent lists)" do
       # Root commits legitimately have parent_revisions == [] when parsed with the parents format.
       # The validation should detect that parent metadata is present (non-nil) and not error.

--- a/spec/ruby_maat/app_spec.rb
+++ b/spec/ruby_maat/app_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyMaat::App do
+  describe "#run with --group-by-merge" do
+    let(:log_file) { File.join(__dir__, "../fixtures/code_maat/end_to_end/simple_git2.txt") }
+
+    it "raises an error when log lacks parent revision metadata" do
+      app = described_class.new(
+        log: log_file,
+        version_control: "git2",
+        analysis: "coupling",
+        group_by_merge: true
+      )
+
+      expect { app.run }.to raise_error(SystemExit).and output(/group-by-merge requires parent revision metadata/).to_stderr
+    end
+  end
+end

--- a/spec/ruby_maat/app_spec.rb
+++ b/spec/ruby_maat/app_spec.rb
@@ -16,5 +16,27 @@ RSpec.describe RubyMaat::App do
 
       expect { app.run }.to raise_error(SystemExit).and output(/group-by-merge requires parent revision metadata/).to_stderr
     end
+
+    it "does not raise when log has parent metadata but only root commits (empty parent lists)" do
+      # Root commits legitimately have parent_revisions == [] when parsed with the parents format.
+      # The validation should detect that parent metadata is present (non-nil) and not error.
+      allow(RubyMaat::Parsers::Git2Parser).to receive(:new).and_return(
+        instance_double(RubyMaat::Parsers::Git2Parser, parse: [
+          RubyMaat::ChangeRecord.new(
+            entity: "file.rb", author: "dev", date: "2024-01-01",
+            revision: "abc123", parent_revisions: []
+          )
+        ])
+      )
+
+      app = described_class.new(
+        log: log_file,
+        version_control: "git2",
+        analysis: "revisions",
+        group_by_merge: true
+      )
+
+      expect { app.run }.not_to raise_error
+    end
   end
 end

--- a/spec/ruby_maat/change_record_spec.rb
+++ b/spec/ruby_maat/change_record_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe RubyMaat::ChangeRecord do
         revision: "abc123",
         message: "Fix bug",
         loc_added: 10,
-        loc_deleted: 5
+        loc_deleted: 5,
+        parent_revisions: nil
       })
     end
   end

--- a/spec/ruby_maat/generators/git_generator_spec.rb
+++ b/spec/ruby_maat/generators/git_generator_spec.rb
@@ -96,6 +96,25 @@ RSpec.describe RubyMaat::Generators::GitGenerator do
       end
     end
 
+    context "with git2-parents format" do
+      it "builds correct git2-parents command with parent hashes" do
+        expected_command = "git log --all --numstat --date=short --pretty=format:'--%h--%p--%ad--%aN--%s' --no-renames"
+        allow(generator).to receive(:execute_command).with(expected_command)
+
+        generator.generate_log(nil, format: "git2-parents", all_branches: true, no_renames: true)
+        expect(generator).to have_received(:execute_command).with(expected_command)
+      end
+    end
+
+    context "with pr-coupling preset" do
+      it "uses git2-parents format" do
+        presets = generator.available_presets
+        pr_preset = presets["pr-coupling"]
+
+        expect(pr_preset[:options][:format]).to eq("git2-parents")
+      end
+    end
+
     context "with date filtering" do
       it "includes date filters in command" do
         expected_command = "git log --all --numstat --date=short --pretty=format:'--%h--%ad--%aN--%s' --no-renames --after=2023-01-01 --before=2023-12-31"

--- a/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
+++ b/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
@@ -131,6 +131,39 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
       expect(rewritten.loc_added).to eq(20)
       expect(rewritten.loc_deleted).to eq(3)
       expect(rewritten.message).to eq("Add feature")
+      expect(rewritten.parent_revisions).to eq(%w[main1])
+    end
+
+    it "handles octopus merges with multiple feature parents" do
+      records = [
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-10", revision: "octopus1",
+          parent_revisions: %w[main1 feat_a1 feat_b1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file_a.rb", author: "bob", date: "2023-01-08", revision: "feat_a1",
+          parent_revisions: %w[main1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file_b.rb", author: "charlie", date: "2023-01-09", revision: "feat_b1",
+          parent_revisions: %w[main1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file0.rb", author: "dave", date: "2023-01-01", revision: "main1",
+          parent_revisions: %w[main0]
+        )
+      ]
+
+      result = grouper.group(records)
+
+      feat_a = result.find { |r| r.entity == "file_a.rb" }
+      expect(feat_a.revision).to eq("octopus1")
+
+      feat_b = result.find { |r| r.entity == "file_b.rb" }
+      expect(feat_b.revision).to eq("octopus1")
+
+      main_record = result.find { |r| r.entity == "file0.rb" }
+      expect(main_record.revision).to eq("main1")
     end
 
     it "handles feature branch commits not present in the log" do

--- a/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
+++ b/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
@@ -127,11 +127,49 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
       expect(rewritten.revision).to eq("merge1")
       expect(rewritten.entity).to eq("file2.rb")
       expect(rewritten.author).to eq("bob")
-      expect(rewritten.date).to eq(Date.parse("2023-01-04"))
+      expect(rewritten.date).to eq(Date.parse("2023-01-05"))
       expect(rewritten.loc_added).to eq(20)
       expect(rewritten.loc_deleted).to eq(3)
       expect(rewritten.message).to eq("Add feature")
       expect(rewritten.parent_revisions).to eq(%w[main1])
+    end
+
+    it "rewrites feature-branch dates to the merge commit date" do
+      records = [
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-10", revision: "merge1",
+          parent_revisions: %w[main1 feat2]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "bob", date: "2023-01-08", revision: "feat2",
+          parent_revisions: %w[feat1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file3.rb", author: "bob", date: "2023-01-06", revision: "feat1",
+          parent_revisions: %w[main1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file0.rb", author: "charlie", date: "2023-01-01", revision: "main1",
+          parent_revisions: %w[main0]
+        )
+      ]
+
+      result = grouper.group(records)
+
+      # Feature-branch records should have the merge commit's date
+      feat2_record = result.find { |r| r.entity == "file2.rb" }
+      expect(feat2_record.date).to eq(Date.parse("2023-01-10"))
+
+      feat1_record = result.find { |r| r.entity == "file3.rb" }
+      expect(feat1_record.date).to eq(Date.parse("2023-01-10"))
+
+      # Merge commit itself keeps its own date
+      merge_record = result.find { |r| r.entity == "file1.rb" }
+      expect(merge_record.date).to eq(Date.parse("2023-01-10"))
+
+      # Unrelated mainline commit keeps its original date
+      main_record = result.find { |r| r.entity == "file0.rb" }
+      expect(main_record.date).to eq(Date.parse("2023-01-01"))
     end
 
     it "handles octopus merges with multiple feature parents" do

--- a/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
+++ b/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
+  let(:grouper) { described_class.new }
+
+  describe "#group" do
+    let(:merge_branch_records) do
+      [
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+          parent_revisions: %w[main1 feat2]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+          parent_revisions: %w[main1 feat2]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "bob", date: "2023-01-04", revision: "feat2",
+          parent_revisions: %w[feat1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file3.rb", author: "bob", date: "2023-01-03", revision: "feat1",
+          parent_revisions: %w[main1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file4.rb", author: "charlie", date: "2023-01-01", revision: "main1",
+          parent_revisions: %w[main0]
+        )
+      ]
+    end
+
+    it "groups feature branch commits under their merge commit" do
+      result = grouper.group(merge_branch_records)
+
+      feat2_record = result.find { |r| r.entity == "file1.rb" && r.author == "bob" }
+      expect(feat2_record.revision).to eq("merge1")
+
+      feat1_record = result.find { |r| r.entity == "file3.rb" }
+      expect(feat1_record.revision).to eq("merge1")
+
+      merge_records = result.select { |r| r.revision == "merge1" }
+      expect(merge_records.size).to eq(4)
+
+      main_record = result.find { |r| r.entity == "file4.rb" }
+      expect(main_record.revision).to eq("main1")
+    end
+
+    it "handles multiple merge commits" do
+      records = [
+        # Second merge
+        RubyMaat::ChangeRecord.new(
+          entity: "file_b.rb", author: "alice", date: "2023-01-10", revision: "merge2",
+          parent_revisions: %w[merge1 feat_b1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file_b.rb", author: "bob", date: "2023-01-09", revision: "feat_b1",
+          parent_revisions: %w[merge1]
+        ),
+        # First merge
+        RubyMaat::ChangeRecord.new(
+          entity: "file_a.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+          parent_revisions: %w[main0 feat_a1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file_a.rb", author: "bob", date: "2023-01-04", revision: "feat_a1",
+          parent_revisions: %w[main0]
+        )
+      ]
+
+      result = grouper.group(records)
+
+      feat_a = result.find { |r| r.author == "bob" && r.entity == "file_a.rb" }
+      expect(feat_a.revision).to eq("merge1")
+
+      feat_b = result.find { |r| r.author == "bob" && r.entity == "file_b.rb" }
+      expect(feat_b.revision).to eq("merge2")
+    end
+
+    it "returns records unchanged when no parent info is available" do
+      records = [
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-01", revision: "rev1"
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "bob", date: "2023-01-02", revision: "rev2"
+        )
+      ]
+
+      result = grouper.group(records)
+
+      expect(result.map(&:revision)).to eq(%w[rev1 rev2])
+    end
+
+    it "returns records unchanged when there are no merge commits" do
+      records = [
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-01", revision: "rev1",
+          parent_revisions: %w[rev0]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "bob", date: "2023-01-02", revision: "rev2",
+          parent_revisions: %w[rev1]
+        )
+      ]
+
+      result = grouper.group(records)
+
+      expect(result.map(&:revision)).to eq(%w[rev1 rev2])
+    end
+
+    it "preserves record attributes when rewriting revision" do
+      records = [
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+          loc_added: 10, loc_deleted: 5, parent_revisions: %w[main1 feat1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "bob", date: "2023-01-04", revision: "feat1",
+          loc_added: 20, loc_deleted: 3, message: "Add feature",
+          parent_revisions: %w[main1]
+        )
+      ]
+
+      result = grouper.group(records)
+      rewritten = result.find { |r| r.author == "bob" }
+
+      expect(rewritten.revision).to eq("merge1")
+      expect(rewritten.entity).to eq("file2.rb")
+      expect(rewritten.author).to eq("bob")
+      expect(rewritten.date).to eq(Date.parse("2023-01-04"))
+      expect(rewritten.loc_added).to eq(20)
+      expect(rewritten.loc_deleted).to eq(3)
+      expect(rewritten.message).to eq("Add feature")
+    end
+
+    it "handles feature branch commits not present in the log" do
+      records = [
+        # Merge commit references a feature tip that's not in the log
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+          parent_revisions: %w[main1 missing_feat]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "bob", date: "2023-01-01", revision: "main1",
+          parent_revisions: %w[main0]
+        )
+      ]
+
+      result = grouper.group(records)
+
+      # Nothing should be rewritten since feature commits aren't in the log
+      expect(result.map(&:revision)).to eq(%w[merge1 main1])
+    end
+  end
+end

--- a/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
+++ b/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
         RubyMaat::ChangeRecord.new(
           entity: "file_a.rb", author: "bob", date: "2023-01-04", revision: "feat_a1",
           parent_revisions: %w[main0]
+        ),
+        # Mainline base commit
+        RubyMaat::ChangeRecord.new(
+          entity: "file_base.rb", author: "charlie", date: "2023-01-01", revision: "main0",
+          parent_revisions: []
         )
       ]
 
@@ -118,6 +123,10 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
           entity: "file2.rb", author: "bob", date: "2023-01-04", revision: "feat1",
           loc_added: 20, loc_deleted: 3, message: "Add feature",
           parent_revisions: %w[main1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file0.rb", author: "charlie", date: "2023-01-01", revision: "main1",
+          parent_revisions: %w[main0]
         )
       ]
 
@@ -202,6 +211,25 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
 
       main_record = result.find { |r| r.entity == "file0.rb" }
       expect(main_record.revision).to eq("main1")
+    end
+
+    it "skips grouping when mainline parent is not in the commit set" do
+      records = [
+        # Merge commit whose mainline parent is not in the log (filtered/truncated log)
+        RubyMaat::ChangeRecord.new(
+          entity: "file1.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+          parent_revisions: %w[missing_main feat1]
+        ),
+        RubyMaat::ChangeRecord.new(
+          entity: "file2.rb", author: "bob", date: "2023-01-04", revision: "feat1",
+          parent_revisions: %w[missing_main]
+        )
+      ]
+
+      result = grouper.group(records)
+
+      # Without a valid mainline parent, grouping should be skipped
+      expect(result.map(&:revision)).to eq(%w[merge1 feat1])
     end
 
     it "handles feature branch commits not present in the log" do

--- a/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
+++ b/spec/ruby_maat/groupers/merge_commit_grouper_spec.rb
@@ -45,40 +45,41 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
       expect(main_record.revision).to eq("main1")
     end
 
-    it "handles multiple merge commits" do
-      records = [
-        # Second merge
-        RubyMaat::ChangeRecord.new(
-          entity: "file_b.rb", author: "alice", date: "2023-01-10", revision: "merge2",
-          parent_revisions: %w[merge1 feat_b1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file_b.rb", author: "bob", date: "2023-01-09", revision: "feat_b1",
-          parent_revisions: %w[merge1]
-        ),
-        # First merge
-        RubyMaat::ChangeRecord.new(
-          entity: "file_a.rb", author: "alice", date: "2023-01-05", revision: "merge1",
-          parent_revisions: %w[main0 feat_a1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file_a.rb", author: "bob", date: "2023-01-04", revision: "feat_a1",
-          parent_revisions: %w[main0]
-        ),
-        # Mainline base commit
-        RubyMaat::ChangeRecord.new(
-          entity: "file_base.rb", author: "charlie", date: "2023-01-01", revision: "main0",
-          parent_revisions: []
-        )
-      ]
+    context "with multiple merge commits" do
+      let(:multi_merge_records) do
+        [
+          RubyMaat::ChangeRecord.new(
+            entity: "file_b.rb", author: "alice", date: "2023-01-10", revision: "merge2",
+            parent_revisions: %w[merge1 feat_b1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file_b.rb", author: "bob", date: "2023-01-09", revision: "feat_b1",
+            parent_revisions: %w[merge1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file_a.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+            parent_revisions: %w[main0 feat_a1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file_a.rb", author: "bob", date: "2023-01-04", revision: "feat_a1",
+            parent_revisions: %w[main0]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file_base.rb", author: "charlie", date: "2023-01-01", revision: "main0",
+            parent_revisions: []
+          )
+        ]
+      end
 
-      result = grouper.group(records)
+      it "groups each feature branch under its respective merge" do
+        result = grouper.group(multi_merge_records)
 
-      feat_a = result.find { |r| r.author == "bob" && r.entity == "file_a.rb" }
-      expect(feat_a.revision).to eq("merge1")
+        feat_a = result.find { |r| r.author == "bob" && r.entity == "file_a.rb" }
+        expect(feat_a.revision).to eq("merge1")
 
-      feat_b = result.find { |r| r.author == "bob" && r.entity == "file_b.rb" }
-      expect(feat_b.revision).to eq("merge2")
+        feat_b = result.find { |r| r.author == "bob" && r.entity == "file_b.rb" }
+        expect(feat_b.revision).to eq("merge2")
+      end
     end
 
     it "returns records unchanged when no parent info is available" do
@@ -113,104 +114,113 @@ RSpec.describe RubyMaat::Groupers::MergeCommitGrouper do
       expect(result.map(&:revision)).to eq(%w[rev1 rev2])
     end
 
-    it "preserves record attributes when rewriting revision" do
-      records = [
-        RubyMaat::ChangeRecord.new(
-          entity: "file1.rb", author: "alice", date: "2023-01-05", revision: "merge1",
-          loc_added: 10, loc_deleted: 5, parent_revisions: %w[main1 feat1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file2.rb", author: "bob", date: "2023-01-04", revision: "feat1",
-          loc_added: 20, loc_deleted: 3, message: "Add feature",
-          parent_revisions: %w[main1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file0.rb", author: "charlie", date: "2023-01-01", revision: "main1",
-          parent_revisions: %w[main0]
-        )
-      ]
+    context "when preserving record attributes" do
+      let(:attribute_records) do
+        [
+          RubyMaat::ChangeRecord.new(
+            entity: "file1.rb", author: "alice", date: "2023-01-05", revision: "merge1",
+            loc_added: 10, loc_deleted: 5, parent_revisions: %w[main1 feat1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file2.rb", author: "bob", date: "2023-01-04", revision: "feat1",
+            loc_added: 20, loc_deleted: 3, message: "Add feature",
+            parent_revisions: %w[main1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file0.rb", author: "charlie", date: "2023-01-01", revision: "main1",
+            parent_revisions: %w[main0]
+          )
+        ]
+      end
 
-      result = grouper.group(records)
-      rewritten = result.find { |r| r.author == "bob" }
+      it "preserves record attributes when rewriting revision" do
+        result = grouper.group(attribute_records)
+        rewritten = result.find { |r| r.author == "bob" }
 
-      expect(rewritten.revision).to eq("merge1")
-      expect(rewritten.entity).to eq("file2.rb")
-      expect(rewritten.author).to eq("bob")
-      expect(rewritten.date).to eq(Date.parse("2023-01-05"))
-      expect(rewritten.loc_added).to eq(20)
-      expect(rewritten.loc_deleted).to eq(3)
-      expect(rewritten.message).to eq("Add feature")
-      expect(rewritten.parent_revisions).to eq(%w[main1])
+        expect(rewritten.revision).to eq("merge1")
+        expect(rewritten.entity).to eq("file2.rb")
+        expect(rewritten.author).to eq("bob")
+        expect(rewritten.date).to eq(Date.parse("2023-01-05"))
+        expect(rewritten.loc_added).to eq(20)
+        expect(rewritten.loc_deleted).to eq(3)
+        expect(rewritten.message).to eq("Add feature")
+        expect(rewritten.parent_revisions).to eq(%w[main1])
+      end
     end
 
-    it "rewrites feature-branch dates to the merge commit date" do
-      records = [
-        RubyMaat::ChangeRecord.new(
-          entity: "file1.rb", author: "alice", date: "2023-01-10", revision: "merge1",
-          parent_revisions: %w[main1 feat2]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file2.rb", author: "bob", date: "2023-01-08", revision: "feat2",
-          parent_revisions: %w[feat1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file3.rb", author: "bob", date: "2023-01-06", revision: "feat1",
-          parent_revisions: %w[main1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file0.rb", author: "charlie", date: "2023-01-01", revision: "main1",
-          parent_revisions: %w[main0]
-        )
-      ]
+    context "when rewriting dates" do
+      let(:date_rewrite_records) do
+        [
+          RubyMaat::ChangeRecord.new(
+            entity: "file1.rb", author: "alice", date: "2023-01-10", revision: "merge1",
+            parent_revisions: %w[main1 feat2]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file2.rb", author: "bob", date: "2023-01-08", revision: "feat2",
+            parent_revisions: %w[feat1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file3.rb", author: "bob", date: "2023-01-06", revision: "feat1",
+            parent_revisions: %w[main1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file0.rb", author: "charlie", date: "2023-01-01", revision: "main1",
+            parent_revisions: %w[main0]
+          )
+        ]
+      end
 
-      result = grouper.group(records)
+      it "rewrites feature-branch dates to the merge commit date" do
+        result = grouper.group(date_rewrite_records)
 
-      # Feature-branch records should have the merge commit's date
-      feat2_record = result.find { |r| r.entity == "file2.rb" }
-      expect(feat2_record.date).to eq(Date.parse("2023-01-10"))
+        feat2_record = result.find { |r| r.entity == "file2.rb" }
+        expect(feat2_record.date).to eq(Date.parse("2023-01-10"))
 
-      feat1_record = result.find { |r| r.entity == "file3.rb" }
-      expect(feat1_record.date).to eq(Date.parse("2023-01-10"))
+        feat1_record = result.find { |r| r.entity == "file3.rb" }
+        expect(feat1_record.date).to eq(Date.parse("2023-01-10"))
 
-      # Merge commit itself keeps its own date
-      merge_record = result.find { |r| r.entity == "file1.rb" }
-      expect(merge_record.date).to eq(Date.parse("2023-01-10"))
+        merge_record = result.find { |r| r.entity == "file1.rb" }
+        expect(merge_record.date).to eq(Date.parse("2023-01-10"))
 
-      # Unrelated mainline commit keeps its original date
-      main_record = result.find { |r| r.entity == "file0.rb" }
-      expect(main_record.date).to eq(Date.parse("2023-01-01"))
+        main_record = result.find { |r| r.entity == "file0.rb" }
+        expect(main_record.date).to eq(Date.parse("2023-01-01"))
+      end
     end
 
-    it "handles octopus merges with multiple feature parents" do
-      records = [
-        RubyMaat::ChangeRecord.new(
-          entity: "file1.rb", author: "alice", date: "2023-01-10", revision: "octopus1",
-          parent_revisions: %w[main1 feat_a1 feat_b1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file_a.rb", author: "bob", date: "2023-01-08", revision: "feat_a1",
-          parent_revisions: %w[main1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file_b.rb", author: "charlie", date: "2023-01-09", revision: "feat_b1",
-          parent_revisions: %w[main1]
-        ),
-        RubyMaat::ChangeRecord.new(
-          entity: "file0.rb", author: "dave", date: "2023-01-01", revision: "main1",
-          parent_revisions: %w[main0]
-        )
-      ]
+    context "with octopus merges" do
+      let(:octopus_records) do
+        [
+          RubyMaat::ChangeRecord.new(
+            entity: "file1.rb", author: "alice", date: "2023-01-10", revision: "octopus1",
+            parent_revisions: %w[main1 feat_a1 feat_b1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file_a.rb", author: "bob", date: "2023-01-08", revision: "feat_a1",
+            parent_revisions: %w[main1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file_b.rb", author: "charlie", date: "2023-01-09", revision: "feat_b1",
+            parent_revisions: %w[main1]
+          ),
+          RubyMaat::ChangeRecord.new(
+            entity: "file0.rb", author: "dave", date: "2023-01-01", revision: "main1",
+            parent_revisions: %w[main0]
+          )
+        ]
+      end
 
-      result = grouper.group(records)
+      it "handles octopus merges with multiple feature parents" do
+        result = grouper.group(octopus_records)
 
-      feat_a = result.find { |r| r.entity == "file_a.rb" }
-      expect(feat_a.revision).to eq("octopus1")
+        feat_a = result.find { |r| r.entity == "file_a.rb" }
+        expect(feat_a.revision).to eq("octopus1")
 
-      feat_b = result.find { |r| r.entity == "file_b.rb" }
-      expect(feat_b.revision).to eq("octopus1")
+        feat_b = result.find { |r| r.entity == "file_b.rb" }
+        expect(feat_b.revision).to eq("octopus1")
 
-      main_record = result.find { |r| r.entity == "file0.rb" }
-      expect(main_record.revision).to eq("main1")
+        main_record = result.find { |r| r.entity == "file0.rb" }
+        expect(main_record.revision).to eq("main1")
+      end
     end
 
     it "skips grouping when mainline parent is not in the commit set" do

--- a/spec/ruby_maat/parsers/git2_parser_spec.rb
+++ b/spec/ruby_maat/parsers/git2_parser_spec.rb
@@ -174,5 +174,51 @@ RSpec.describe RubyMaat::Parsers::Git2Parser do
         expect(merge_record.loc_deleted).to eq(2)
       end
     end
+
+    context "with hyphenated author names" do
+      it "parses authors containing hyphens in standard format" do
+        log = <<~LOG
+          --abc123--2023-03-01--Jean-Pierre Dupont--Fix encoding issue
+          4       1       lib/encoding.rb
+        LOG
+
+        file = Tempfile.new(["git2_hyphen", ".log"])
+        file.write(log)
+        file.close
+
+        begin
+          parser = described_class.new(file.path)
+          records = parser.parse
+
+          expect(records.size).to eq(1)
+          expect(records[0].author).to eq("Jean-Pierre Dupont")
+          expect(records[0].revision).to eq("abc123")
+        ensure
+          file.unlink
+        end
+      end
+
+      it "parses authors containing hyphens in parent hash format" do
+        log = <<~LOG
+          --abc123--def456 ghi789--2023-03-01--Jean-Pierre Dupont--Merge feature branch
+          4       1       lib/encoding.rb
+        LOG
+
+        file = Tempfile.new(["git2_hyphen_parents", ".log"])
+        file.write(log)
+        file.close
+
+        begin
+          parser = described_class.new(file.path)
+          records = parser.parse
+
+          expect(records.size).to eq(1)
+          expect(records[0].author).to eq("Jean-Pierre Dupont")
+          expect(records[0].parent_revisions).to eq(%w[def456 ghi789])
+        ensure
+          file.unlink
+        end
+      end
+    end
   end
 end

--- a/spec/ruby_maat/parsers/git2_parser_spec.rb
+++ b/spec/ruby_maat/parsers/git2_parser_spec.rb
@@ -108,5 +108,71 @@ RSpec.describe RubyMaat::Parsers::Git2Parser do
 
       expect { parser.parse }.to raise_error(ArgumentError, /Log file not found/)
     end
+
+    context "with parent hashes format" do
+      let(:log_with_parents) do
+        <<~LOG
+          --aaa111--bbb222 ccc333--2023-01-20--Alice--Merge PR #42
+          5       2       src/feature.rb
+          3       0       test/feature_test.rb
+
+          --bbb222--ddd444--2023-01-19--Bob--Add feature implementation
+          10      0       src/feature.rb
+
+          --ccc333--ddd444--2023-01-18--Charlie--Update docs
+          2       1       README.md
+
+          --ddd444----2023-01-17--Alice--Initial commit
+          100     0       src/main.rb
+        LOG
+      end
+
+      let(:parents_file) do
+        file = Tempfile.new(["git2_parents_log", ".log"])
+        file.write(log_with_parents)
+        file.close
+        file
+      end
+
+      after { parents_file.unlink }
+
+      it "parses commit lines with parent hashes" do
+        parser = described_class.new(parents_file.path)
+        records = parser.parse
+
+        expect(records.size).to eq(5)
+
+        # Merge commit (two parents)
+        merge_record = records[0]
+        expect(merge_record.revision).to eq("aaa111")
+        expect(merge_record.parent_revisions).to eq(%w[bbb222 ccc333])
+        expect(merge_record.merge_commit?).to be true
+
+        # Regular commit (one parent)
+        regular_record = records[2]
+        expect(regular_record.revision).to eq("bbb222")
+        expect(regular_record.parent_revisions).to eq(%w[ddd444])
+        expect(regular_record.merge_commit?).to be false
+
+        # Root commit (no parents)
+        root_record = records[4]
+        expect(root_record.revision).to eq("ddd444")
+        expect(root_record.parent_revisions).to eq([])
+        expect(root_record.merge_commit?).to be false
+      end
+
+      it "preserves standard fields when parsing parent format" do
+        parser = described_class.new(parents_file.path)
+        records = parser.parse
+
+        merge_record = records[0]
+        expect(merge_record.entity).to eq("src/feature.rb")
+        expect(merge_record.author).to eq("Alice")
+        expect(merge_record.date).to eq(Date.parse("2023-01-20"))
+        expect(merge_record.message).to eq("Merge PR #42")
+        expect(merge_record.loc_added).to eq(5)
+        expect(merge_record.loc_deleted).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Enable better coupling analysis for merge-based workflows (e.g., GitHub PRs) by detecting merge commits and grouping their constituent commits into single logical changesets, so files changed across a PR are treated as co-changing rather than analyzed per-commit.

## Changes

**Data model**
- Added optional `parent_revisions` field and `merge_commit?` helper to `ChangeRecord`

**Parsing**
- Extended `Git2Parser` to support a new log format that includes parent hashes (`--%h--%p--%ad--%aN--%s`); backward compatible with the existing format

**Grouping logic**
- New `MergeCommitGrouper` that identifies merge commits (2+ parents), walks the commit graph to find feature branch commits belonging to each merge, and rewrites their revision to the merge commit's hash so coupling treats all PR files as co-changing

**Presets & CLI**
- Added `pr-coupling` preset to `GitGenerator` that produces logs with parent hashes
- Added `--group-by-merge` CLI option
- Wired merge grouping into the `App` pipeline, running before other transformations

## Design Decisions

- **Graph walking over GitHub API**: The grouper infers PR membership purely from the merge commit DAG, requiring no GitHub access. This keeps the tool VCS-only and answers the issue's question ("Can we figure out what PRs contain without access to GitHub?").
- **Revision rewriting strategy**: Rather than introducing a new "group" concept throughout the pipeline, child commits are rewritten to share the merge commit's hash. This lets existing coupling analysis work unchanged — it simply sees fewer, larger changesets.
- **Backward compatibility**: The extended log format is opt-in via the `pr-coupling` preset; the standard format and default behavior are unaffected.

---

Closes #37